### PR TITLE
Release 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [unreleased]
 
+## [4.0.0] - 2026-06-13
+
+### Changed
+
+- Update default runtime to node24.
+
 ## [3.0.0] - 2023-11-24
 
 ### Changed
@@ -85,7 +91,8 @@ and this project adheres to
 - Initial release.
 
 [unreleased]:
-  https://github.com/fossa-contrib/fossa-action/compare/v3.0.0...HEAD
+  https://github.com/fossa-contrib/fossa-action/compare/v4.0.0...HEAD
+[4.0.0]: https://github.com/fossa-contrib/fossa-action/compare/v3.0.0...v4.0.0
 [3.0.0]: https://github.com/fossa-contrib/fossa-action/compare/v2.0.0...v3.0.0
 [2.0.0]: https://github.com/fossa-contrib/fossa-action/compare/v1.2.0...v2.0.0
 [1.2.0]: https://github.com/fossa-contrib/fossa-action/compare/v1.1.5...v1.2.0

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ specify the version of the action _itself_.
 
 ```yml
 - name: Run FOSSA scan and upload build data
-  uses: fossa-contrib/fossa-action@v3
+  uses: fossa-contrib/fossa-action@v4
   #                               ^^^
   with:
     fossa-api-key: abcdefghijklmnopqrstuvwxyz
@@ -66,17 +66,17 @@ specify the version of the action _itself_.
 
 We recommend that you include the version of the action. We adhere to
 [semantic versioning](https://semver.org), it's safe to use the major version
-(`v1`) in your workflow. If you use the master branch, this could break your
+(`v4`) in your workflow. If you use the master branch, this could break your
 workflow when we publish a breaking update and increase the major version.
 
 ```yml
 steps:
   # Reference the major version of a release (most recommended)
-  - uses: fossa-contrib/fossa-action@v3
+  - uses: fossa-contrib/fossa-action@v4
   # Reference a specific commit (most strict)
   - uses: fossa-contrib/fossa-action@cdc5065
   # Reference a semver version of a release (not recommended)
-  - uses: fossa-contrib/fossa-action@v3.0.0
+  - uses: fossa-contrib/fossa-action@v4.0.0
   # Reference a branch (most dangerous)
   - uses: fossa-contrib/fossa-action@master
 ```

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.5.0",
         "@tsconfig/node24": "24.0.4",
         "@tsconfig/strictest": "2.0.8",
-        "@types/node": "25.3.1",
+        "@types/node": "25.9.3",
         "@types/semver": "7.7.1",
         "esbuild": "0.28.1",
         "typescript": "6.0.3",
@@ -129,7 +129,7 @@
 
     "@tsconfig/strictest": ["@tsconfig/strictest@2.0.8", "", {}, "sha512-XnQ7vNz5HRN0r88GYf1J9JJjqtZPiHt2woGJOo2dYqyHGGcd6OLGqSlBB6p1j9mpzja6Oe5BoPqWmeDx6X9rLw=="],
 
-    "@types/node": ["@types/node@25.3.1", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw=="],
+    "@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
 
     "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
 
@@ -149,7 +149,7 @@
 
     "undici": ["undici@6.26.0", "", {}, "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A=="],
 
-    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -29272,19 +29272,9 @@ async function analyze() {
   const arguments_ = getArguments();
   const PATH = process.env.PATH ?? "";
   const options = { env: { ...process.env, PATH, FOSSA_API_KEY } };
-  await exec(
-    "fossa",
-    ["analyze", ...arguments_],
-    // @ts-expect-error: process.env may contain undefined values
-    options
-  );
+  await exec("fossa", ["analyze", ...arguments_], options);
   if (!SKIP_TEST) {
-    await exec(
-      "fossa",
-      ["test", ...arguments_],
-      // @ts-expect-error: process.env may contain undefined values
-      options
-    );
+    await exec("fossa", ["test", ...arguments_], options);
   }
 }
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
 bun = "latest"
-node = "25.7.0"
+node = "24"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@biomejs/biome": "2.5.0",
     "@tsconfig/node24": "24.0.4",
     "@tsconfig/strictest": "2.0.8",
-    "@types/node": "25.3.1",
+    "@types/node": "25.9.3",
     "@types/semver": "7.7.1",
     "esbuild": "0.28.1",
     "typescript": "6.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fossa-action",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "private": true,
   "description": "Actions for running FOSSA scans",
   "license": "ISC",

--- a/renovate.json
+++ b/renovate.json
@@ -6,9 +6,7 @@
     "schedule:daily",
     ":disableRateLimiting",
     ":maintainLockFilesWeekly",
-    ":pinVersions",
     ":semanticCommitsDisabled"
   ],
-  "postUpdateOptions": ["yarnDedupeHighest"],
   "rebaseWhen": "conflicted"
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -22,6 +22,9 @@ function Release() {
 
   echo "Push tags"
   git push --tags
+
+  echo "Create a GitHub release: $FULL_VERSION"
+  gh release create "$FULL_VERSION" --generate-notes
 }
 
 Release "$1" "$2"

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -14,18 +14,8 @@ export async function analyze(): Promise<void> {
   const arguments_ = getArguments();
   const PATH = process.env.PATH ?? "";
   const options = { env: { ...process.env, PATH, FOSSA_API_KEY } };
-  await exec(
-    "fossa",
-    ["analyze", ...arguments_],
-    // @ts-expect-error: process.env may contain undefined values
-    options,
-  );
+  await exec("fossa", ["analyze", ...arguments_], options);
   if (!SKIP_TEST) {
-    await exec(
-      "fossa",
-      ["test", ...arguments_],
-      // @ts-expect-error: process.env may contain undefined values
-      options,
-    );
+    await exec("fossa", ["test", ...arguments_], options);
   }
 }


### PR DESCRIPTION
## Summary

- Major release (v4.0.0 / v4) that updates the default runtime to node24
- Bump `package.json` version to 4.0.0
- Add the 4.0.0 entry and comparison links to `CHANGELOG.md`
- Update usage examples and version references in `README.md` to the v4 line
- Add a `gh release create --generate-notes` step to `scripts/release.sh`, modeled after [ocaml/setup-ocaml's release.sh](https://github.com/ocaml/setup-ocaml/blob/master/scripts/release.sh)
- Simplify the Renovate config and pin the mise `node` tool to the `24` major

## Release steps

After merging, run the following on `master` to create the tags and the GitHub release:

```sh
bash scripts/release.sh v4 v4.0.0
```